### PR TITLE
Update react-native-vector-icons dependency to 2.0.3, fix warning for TouchableWithoutFeedback and right PropTypes for the Toolbar style property

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -235,15 +235,17 @@ export default class Toolbar extends Component {
                 {
                     !this.state.isSearchActive &&
                     <TouchableWithoutFeedback onPress={onTitlePress}>
-                        <Text
-                          numberOfLines={1}
-                          style={[styles.title, TYPO.paperFontTitle, {
-                              color: styleMap.color,
-                              marginLeft: iconMap ? styles.title.marginLeft : 16
-                          }]}
-                        >
-                            {title}
-                        </Text>
+                        <View style={{ flex: 1, flexDirection: 'row' }}>
+                            <Text
+                              numberOfLines={1}
+                              style={[styles.title, TYPO.paperFontTitle, {
+                                  color: styleMap.color,
+                                  marginLeft: iconMap ? styles.title.marginLeft : 16
+                              }]}
+                            >
+                                {title}
+                            </Text>
+                        </View>
                     </TouchableWithoutFeedback>
                 }
                 {

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -41,7 +41,7 @@ export default class Toolbar extends Component {
         onTitlePress: PropTypes.func,
         theme: PropTypes.oneOf(THEME_NAME),
         primary: PropTypes.oneOf(PRIMARY_COLORS),
-        style: PropTypes.object,
+        style: View.propTypes.style,
         leftIconStyle: PropTypes.object,
         rightIconStyle: PropTypes.object,
         elevation: PropTypes.number,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/xotahal/react-native-material-ui",
   "dependencies": {
     "react-native-material-design-styles": "^0.2.6",
-    "react-native-vector-icons": "^1.0.3"
+    "react-native-vector-icons": "^2.0.3"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0-beta.6",


### PR DESCRIPTION
There are 3 different commits on this PR.

### 1.  Updated the current dependency of the `react-native-vector-icons` to `2.0.3`.
https://github.com/xotahal/react-native-material-ui/pull/11/commits/516722f58c610af75354d5ce3dbdd67c1df85846

The old version `1.0.3` cause an error with the old react version,like this
![image](https://cloud.githubusercontent.com/assets/1641990/16999737/1d66f2ec-4ef2-11e6-9a00-b9696c5971ec.png)

This is tested with the latest `react-native` build `0.29`

Another option is to make the user install it as separate dependency so they can update without a problem. There is an [easy setup](https://github.com/oblador/react-native-vector-icons#android) for this

----

### 2. as of `0.29` react native. It will give us a warning to not use `Text` component under `TouchableWithoutFeedback`
https://github.com/xotahal/react-native-material-ui/pull/11/commits/fdbf886477b82ec4007cf8a780401396b7bb4c65
![image](https://cloud.githubusercontent.com/assets/1641990/17000256/39030336-4ef4-11e6-8b80-20ea40e896a2.png)
Which actually reverts your previous commit https://github.com/xotahal/react-native-material-ui/blob/9a0c57511ea871dc6f167871707e29de80167a57/lib/Toolbar.js

Which also I applied a fix to align the Title in the center, notice the `flexDirection: 'row'` style property that's the key to it.

### 3. Use the right PropTypes for the Toolbar style property
https://github.com/xotahal/react-native-material-ui/pull/11/commits/6f338e9609f187dab7856aeeabf12a57457f2268
![image](https://cloud.githubusercontent.com/assets/1641990/17000391/e2da29e8-4ef4-11e6-8ea4-38796d235918.png)
