### PR TITLE
Drawer: removed flex style property on section component

### DIFF
--- a/lib/Drawer/Section.js
+++ b/lib/Drawer/Section.js
@@ -7,7 +7,6 @@ import Ripple from '../polyfill/Ripple';
 
 const styles = {
     section: {
-        flex: 1,
         marginTop: 8,
     },
     item: {


### PR DESCRIPTION
This will fix the bug on the section component of the drawer. If you only have 1 item on a single section component, It will take too much space to render the second section component and somehow the height being is unknown. The culprit is the **flex** style property.

Take a look at this code

```
<Drawer.Section
  items={[{
    icon: 'playlist-add-check',
    value: 'Todos',
    label: '0'
  }]}
/>

<Divider/>

<Drawer.Section
  items={[{
    icon: 'settings',
    value: 'Settings'
  }, {
    icon: 'info',
    value: 'About'
  }, {
    icon: 'power-settings-new',
    value: 'Logout'
  }]}
/>
</Drawer>
```

It looks like this this
![image](https://cloud.githubusercontent.com/assets/1641990/17331794/018cee3e-58ff-11e6-94e4-dbf9bf337fec.png)

and this is the final form after the changes. They stack pretty well.
![image](https://cloud.githubusercontent.com/assets/1641990/17331812/186822fe-58ff-11e6-91e8-6a167fb395a1.png)

