### PR TITLE
Update readme to add the recommended way of linking packages like react-native-vector-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,21 @@ npm i react-native-material-ui --save
 ## Setting of vector icons
 You can see [this repo](https://github.com/oblador/react-native-vector-icons) for much more information.
 
-### Android (see [original](https://github.com/oblador/react-native-vector-icons#android))
+### React Native Link (recommended)
+> Make sure you have atleast v0.31.0 react-native version.
+
+```bash
+react-native link react-native-vector-icons
+```
+
+### Manual Installation
+
+#### Android (see [original](https://github.com/oblador/react-native-vector-icons#android))
 Copy the `MaterialIcons` font file from [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons#android) to your local working directory:
 
 `./node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf` -> `./android/app/src/main/assets/fonts`.
 
-### iOS (see [original](https://github.com/oblador/react-native-vector-icons#ios))
+#### iOS (see [original](https://github.com/oblador/react-native-vector-icons#ios))
 
 # Usage
 


### PR DESCRIPTION
Added a better way to link packages, since 0.31 with this [PR](https://github.com/facebook/react-native/commit/e8b508144fdcdea436cf4d80d99daec757505c70) of react native they merge [rnpm](https://github.com/rnpm/rnpm) to the core. This is the safest way to install and link packages with your current app build.

You can look my [forked repo](https://github.com/kenma9123/react-native-material-ui) for README.md preview.