### PR TITLE
Making Disabled Button Look Disabled

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -85,6 +85,8 @@ function getStyles(props, context, state) {
         };
     }
 
+    console.log(buttonDisabled.container);
+
     return {
         container: [
             button.container,
@@ -138,7 +140,6 @@ class Button extends PureComponent {
             return null;
         }
 
-
         return (
             <Icon
                 name={icon}
@@ -152,8 +153,7 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
-        console.log(styles);
-
+        
         const content = (
             <View style={styles.container}>
                 {this.renderIcon(styles)}

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -64,18 +64,23 @@ function getStyles(props, context, state) {
         container: {},
     };
 
-    if (primary && !raised) {
-        local.text = { color: palette.primaryColor };
-    } else if (accent && !raised) {
-        local.text = { color: palette.accentColor };
-    }
+    if(!disabled){
+        //Is this really necessary?  Isn't it handled in getTheme.js? 
+        //Answer = It's not, base controls are stored in getTheme and the control itself determines colors... 
+        //seems backwards.
+        if (primary && !raised) {
+            local.text = { color: palette.primaryColor };
+        } else if (accent && !raised) {
+            local.text = { color: palette.accentColor };
+        }
 
-    if (primary && raised) {
-        local.container.backgroundColor = palette.primaryColor;
-        local.text = { color: palette.canvasColor };
-    } else if (accent && raised) {
-        local.container.backgroundColor = palette.accentColor;
-        local.text = { color: palette.canvasColor };
+        if (primary && raised) {
+            local.container.backgroundColor = palette.primaryColor;
+            local.text = { color: palette.canvasColor };
+        } else if (accent && raised) {
+            local.container.backgroundColor = palette.accentColor;
+            local.text = { color: palette.canvasColor };
+        }
     }
 
     if (raised) {
@@ -84,23 +89,26 @@ function getStyles(props, context, state) {
             ...getPlatformElevation(state.elevation),
         };
     }
-
-    console.log(buttonDisabled.container);
-
+    //This seems a bit stange at first glance 
+    //since we are returning a list of refferences that may contain false or undefined.
+    //Not only that but all of the base styling is stored in an external file... 
+    //Wouldnt' it make more sense to include it in the components file for better encapsulation?
+    //I would've expected to see theme info in the getTheme not the base settings for the control itself...
     return {
         container: [
             button.container,
             !raised && buttonFlat.container,
-            disabled && buttonDisabled.container,
             raised && buttonRaised.container,
+            (disabled && raised) && buttonRaisedDisabled.container,            
             local.container,
             props.style.container,
         ],
         text: [
             button.text,
             !raised && buttonFlat.text,
-            disabled && buttonDisabled.text,
             raised && buttonRaised.text,
+            (disabled && raised) && buttonRaisedDisabled.text,
+            (disabled && !raised) && buttonDisabled.text,
             local.text,
             props.style.text,
         ],

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -56,15 +56,15 @@ const contextTypes = {
 };
 
 function getStyles(props, context, state) {
-    const { button, buttonFlat, buttonRaised, buttonDisabled, buttonRaisedDisabled } = context.uiTheme;
+    const { button, buttonFlat, buttonRaised } = context.uiTheme;
+    const { palette, buttonDisabled, buttonRaisedDisabled } = context.uiTheme;
     const { primary, accent, disabled, raised } = props;
-    const { palette } = context.uiTheme;
 
     const local = {
         container: {},
     };
 
-    if(!disabled){
+    if (!disabled) {
         if (primary && !raised) {
             local.text = { color: palette.primaryColor };
         } else if (accent && !raised) {
@@ -154,7 +154,7 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
-        
+
         const content = (
             <View style={styles.container}>
                 {this.renderIcon(styles)}

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -161,6 +161,7 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
+        console.log(styles);
         
         const content = (
             <View style={styles.container}>

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -56,7 +56,7 @@ const contextTypes = {
 };
 
 function getStyles(props, context, state) {
-    const { button, buttonFlat, buttonDisabled, buttonRaised } = context.uiTheme;
+    const { button, buttonFlat, buttonRaised, buttonDisabled, buttonRaisedDisabled } = context.uiTheme;
     const { primary, accent, disabled, raised } = props;
     const { palette } = context.uiTheme;
 

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -163,7 +163,8 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
-        console.log(text + ": " styles);
+        console.log(text);
+        console.log(styles);
         
         const content = (
             <View style={styles.container}>

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -152,6 +152,7 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
+        console.log(styles);
 
         const content = (
             <View style={styles.container}>

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -94,23 +94,25 @@ function getStyles(props, context, state) {
     //Not only that but all of the base styling is stored in an external file... 
     //Wouldnt' it make more sense to include it in the components file for better encapsulation?
     //I would've expected to see theme info in the getTheme not the base settings for the control itself...
+
+    //Disabled attribute should over-ride style props as those are likely for the active state.
     return {
         container: [
             button.container,
             !raised && buttonFlat.container,
             raised && buttonRaised.container,
-            (disabled && raised) && buttonRaisedDisabled.container,            
             local.container,
             props.style.container,
+            (disabled && raised) && buttonRaisedDisabled.container,
         ],
         text: [
             button.text,
             !raised && buttonFlat.text,
             raised && buttonRaised.text,
-            (disabled && raised) && buttonRaisedDisabled.text,
-            (disabled && !raised) && buttonDisabled.text,
             local.text,
             props.style.text,
+            (disabled && raised) && buttonRaisedDisabled.text,
+            (disabled && !raised) && buttonDisabled.text,
         ],
     };
 }
@@ -161,7 +163,7 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
-        console.log(styles);
+        console.log(text + ": " styles);
         
         const content = (
             <View style={styles.container}>

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -65,9 +65,6 @@ function getStyles(props, context, state) {
     };
 
     if(!disabled){
-        //Is this really necessary?  Isn't it handled in getTheme.js? 
-        //Answer = It's not, base controls are stored in getTheme and the control itself determines colors... 
-        //seems backwards.
         if (primary && !raised) {
             local.text = { color: palette.primaryColor };
         } else if (accent && !raised) {
@@ -89,13 +86,7 @@ function getStyles(props, context, state) {
             ...getPlatformElevation(state.elevation),
         };
     }
-    //This seems a bit stange at first glance 
-    //since we are returning a list of refferences that may contain false or undefined.
-    //Not only that but all of the base styling is stored in an external file... 
-    //Wouldnt' it make more sense to include it in the components file for better encapsulation?
-    //I would've expected to see theme info in the getTheme not the base settings for the control itself...
 
-    //Disabled attribute should over-ride style props as those are likely for the active state.
     return {
         container: [
             button.container,
@@ -163,8 +154,6 @@ class Button extends PureComponent {
         const { text, disabled, raised, upperCase, onLongPress } = this.props;
 
         const styles = getStyles(this.props, this.context, this.state);
-        console.log(text);
-        console.log(styles);
         
         const content = (
             <View style={styles.container}>

--- a/src/styles/getTheme.js
+++ b/src/styles/getTheme.js
@@ -153,6 +153,15 @@ export default function getTheme(theme, ...more) {
                 color: palette.disabledTextColor,
             },
         }, theme.buttonDisabled)),
+        buttonRaisedDisabled: StyleSheet.create(merge({
+            container: {
+                backgroundColor: palette.disabledColor,
+                borderColor: 'rgba(0,0,0,.12)',
+            },
+            text: {
+                color: palette.canvasColor,
+            },
+        }, theme.buttonDisabled)),
         bottomNavigation: StyleSheet.create(merge({
             container: {
                 flexDirection: 'row',


### PR DESCRIPTION
Currently when you declare a button as raised, primary and disabled at the same time it will render incorrectly to the user.

I've adjusted it so that it'll render right for this use case.  Didn't test it against all the other use cases though.  

Also if you have a road map of the things you'd like help with please let me know.  I'm using this library in my app and I love it so far and I'd be happy to contribute.  Just let me know how I can help.  

Also if you look back through the commits you'll see some of my notes as I wondered through and figuring out how and why you did things the way you did.  Not sure if you'd be open to this but it miht make more sense to architect the contols like the guys over at Material UI did where the core styles reside in the component and the getTheme focuses on the theme specific portions.  If you compare your button with thiers you see what I mean: https://github.com/callemall/material-ui/blob/master/src/RaisedButton/RaisedButton.js

Thanks for all the hard work and this again and let me know how I can hlep more!