### PR TITLE
make react-native-vector-icons a peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jest": "^17.0.3",
     "react": "^15.4.1",
     "react-native": "^0.39.2",
-    "react-native-vector-icons": "^3.0.0"
+    "react-native-vector-icons": "^3.0.0",
     "react-test-renderer": "^15.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "url": "https://github.com/xotahal/react-native-material-ui/issues"
   },
   "homepage": "https://github.com/xotahal/react-native-material-ui",
+  "peerDependencies": {
+    "react-native-vector-icons": "^3.0.0"
+  },
   "dependencies": {
     "color": "^1.0.3",
     "lodash.merge": "^4.0.0",
     "react-native-material-design-styles": "^0.2.6",
-    "react-native-vector-icons": "3.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jest": "^17.0.3",
     "react": "^15.4.1",
     "react-native": "^0.39.2",
+    "react-native-vector-icons": "^3.0.0"
     "react-test-renderer": "^15.4.1"
   }
 }


### PR DESCRIPTION
I have two versions of react-native-vector-icons installed in my project because it's a dependency in this project.

react-native-vector-icon should really be a peerDependency and let the project's package.json dictate the version to use.

cc @xotahal 