### PR TITLE
Added user supplied fontFamily to Toolbar and Dialog title

### DIFF
--- a/src/styles/getTheme.js
+++ b/src/styles/getTheme.js
@@ -224,7 +224,7 @@ export default function getTheme(theme, ...more) {
                 paddingBottom: 20,
             },
             titleText: {
-            	fontFamily,
+                fontFamily,
                 fontSize: 20,
                 fontWeight: 'bold',
                 color: 'black',
@@ -446,7 +446,7 @@ export default function getTheme(theme, ...more) {
                 marginLeft: 20,
             },
             titleText: {
-            	fontFamily,
+                fontFamily,
                 color: palette.alternateTextColor,
                 ...typography.appBar,
             },
@@ -466,7 +466,7 @@ export default function getTheme(theme, ...more) {
             },
             centerElementContainer: { },
             titleText: {
-            	fontFamily,
+                fontFamily,
                 flex: 1,
                 marginLeft: 16,
                 color: palette.primaryTextColor,

--- a/src/styles/getTheme.js
+++ b/src/styles/getTheme.js
@@ -224,6 +224,7 @@ export default function getTheme(theme, ...more) {
                 paddingBottom: 20,
             },
             titleText: {
+            	fontFamily,
                 fontSize: 20,
                 fontWeight: 'bold',
                 color: 'black',
@@ -445,6 +446,7 @@ export default function getTheme(theme, ...more) {
                 marginLeft: 20,
             },
             titleText: {
+            	fontFamily,
                 color: palette.alternateTextColor,
                 ...typography.appBar,
             },
@@ -464,6 +466,7 @@ export default function getTheme(theme, ...more) {
             },
             centerElementContainer: { },
             titleText: {
+            	fontFamily,
                 flex: 1,
                 marginLeft: 16,
                 color: palette.primaryTextColor,


### PR DESCRIPTION
The `fontFamily` style attribute that the user provides through `ThemeProvider.uiTheme.fontFamily` is not used in the title of `Toolbar` or `Dialog`.
This problem might also arise in other situations.