### PR TITLE
Add Avatar documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can try our [Demo App](https://github.com/xotahal/react-native-material-ui-d
 Here is a list of all component included in this library. (I'm working on documentation for every each component. Be patient please :))
 
 - [Action Button](https://github.com/xotahal/react-native-material-ui/blob/master/docs/ActionButton.md)
-- Avatar
+- [Avatar](https://github.com/xotahal/react-native-material-ui/blob/master/docs/Avatar.md)
 - [Badge](https://github.com/xotahal/react-native-material-ui/blob/master/docs/Badge.md)
 - [Bottom Navigation](https://github.com/xotahal/react-native-material-ui/blob/master/docs/BottomNavigation.md)
 - [Button](https://github.com/xotahal/react-native-material-ui/blob/master/docs/Button.md)

--- a/docs/Avatar.md
+++ b/docs/Avatar.md
@@ -1,0 +1,55 @@
+# Avatar
+
+### Usage
+
+```js
+...
+import { Avatar } from '../react-native-material-ui';
+...
+render() {
+    <View>
+        <Avatar text="A" />
+
+        <Avatar icon="grade" />
+        <Avatar icon="person" iconColor="blue" />
+        <Avatar icon="history" iconSize={20} />
+        <Avatar icon="mic" size={75} />
+    </View>
+}
+```
+### API
+```js
+const propTypes = {
+    /**
+    * If passed in, this component will render image.
+    */
+    image: PropTypes.shape({ type: PropTypes.oneOf([Image]) }),
+    /**
+    * If passed in, this component will render icon element inside avatar.
+    */
+    icon: PropTypes.string,
+    /**
+    * If passed in, this component will render an icon with this color.
+    */
+    iconColor: PropTypes.string,
+    /**
+    * If passed in, this component will render an icon with this size.
+    */
+    iconSize: PropTypes.number,
+    /**
+    * If passed in, this component will render text element inside avatar.
+    */
+    text: PropTypes.string,
+    /**
+    * It's just sugar for: style: { width: size, height: size, borderRadius: size / 2 }
+    */
+    size: PropTypes.number,
+    /**
+    * Inline style of avatar
+    */
+    style: PropTypes.shape({
+        container: View.propTypes.style,
+        content: Text.propTypes.style,
+    }),
+};
+```


### PR DESCRIPTION
This will add documentation for the Avatar component. This component is pretty hefty, so it's nice to have some documentation and usage examples in order to see exactly how it can be used.