### PR TITLE
Allow elements to be passed into ListItem centerElement shape

### DIFF
--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -35,9 +35,18 @@ const propTypes = {
         PropTypes.element,
         PropTypes.string,
         PropTypes.shape({
-            primaryText: PropTypes.string.isRequired,
-            secondaryText: PropTypes.string,
-            tertiaryText: PropTypes.string,
+            primaryText: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.element,
+            ]).isRequired,
+            secondaryText: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.element,
+            ]),
+            tertiaryText: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.element,
+            ]),
         }),
     ]),
 


### PR DESCRIPTION
Allow elements to be passed as primaryText, secondaryText, and tertiaryText. Particular use case is the `react-intl` library, which outputs a wrapping `<Text>` element when using `FormattedMessage`