### PR TITLE
Fix issue #74

### DIFF
--- a/src/Toolbar/CenterElement.react.js
+++ b/src/Toolbar/CenterElement.react.js
@@ -8,7 +8,7 @@ const propTypes = {
     searchValue: PropTypes.string.isRequired,
     searchable: PropTypes.object,
     style: PropTypes.object,
-    centerElement: PropTypes.node.isRequired,
+    centerElement: PropTypes.node,
     onPress: PropTypes.func,
     onSearchTextChange: PropTypes.func.isRequired,
 };

--- a/src/Toolbar/CenterElement.react.js
+++ b/src/Toolbar/CenterElement.react.js
@@ -111,10 +111,6 @@ class CenterElement extends PureComponent {
             content = centerElement;
         }
 
-        if (!content) {
-            return null;
-        }
-
         return (
             <TouchableWithoutFeedback key="center" onPress={onPress}>
                 <Animated.View


### PR DESCRIPTION
Fix issue #74 

```
<Toolbar
    rightElement={<BorderedButton accent text="follow" />}
/>
```
if `centerElement` prop is not specified, for example, `CenterElement` component returns `null`.
I think that cause the problem. So, I have just removed below source.

```
if (!content) {
    return null;
}
```
