### PR TITLE
Graceful deprecation for BackAndroid

### DIFF
--- a/src/Toolbar/Toolbar.react.js
+++ b/src/Toolbar/Toolbar.react.js
@@ -4,7 +4,8 @@ import {
     Animated,
     Easing,
     Platform,
-    BackAndroid,
+    BackAndroid as DeprecatedBackAndroid,
+    BackHandler,
     StyleSheet,
     Text,
     View,
@@ -15,6 +16,8 @@ import CenterElement from './CenterElement.react';
 import RightElement from './RightElement.react';
 import IconToggle from '../IconToggle';
 import isFunction from '../utils/isFunction';
+
+const BackAndroid = BackHandler || DeprecatedBackAndroid;
 
 const propTypes = {
     /**


### PR DESCRIPTION
Gracefully deprecates BackAndroid with support for versions going forward as well as older versions.

Proper fix for #139 