### PR TITLE
Feature: Avoid snackbar method for action button

### DIFF
--- a/src/ActionButton/ActionButton.react.js
+++ b/src/ActionButton/ActionButton.react.js
@@ -169,6 +169,7 @@ class ActionButton extends PureComponent {
             render: 'button',
             elevation: 2,
             scaleValue: new Animated.Value(scaleValue),
+            snackbarOffset: new Animated.Value(0),
         };
     }
     componentWillReceiveProps(nextProps) {
@@ -288,7 +289,7 @@ class ActionButton extends PureComponent {
         const mainIcon = render !== 'button' ? 'clear' : icon;
 
         return (
-            <View key="main-button" style={styles.container}>
+            <Animated.View key="main-button" style={[styles.container, { marginBottom: this.state.snackbarOffset }]}>
                 <RippleFeedback
                     color="#AAF"
                     onPress={() => this.onPress('main-button')}
@@ -299,7 +300,7 @@ class ActionButton extends PureComponent {
                 >
                     {this.renderIconButton(styles, mainIcon)}
                 </RippleFeedback>
-            </View>
+            </Animated.View>
         );
     }
     renderToolbarAction = (styles, icon, name) => {
@@ -396,6 +397,27 @@ class ActionButton extends PureComponent {
                 {result}
             </View>
         );
+    }
+    avoidSnackbar({spring, delay, height}) {
+        const animation = Animated.sequence([
+            Animated.timing(
+                this.state.snackbarOffset,
+                {
+                    toValue: height,
+                    duration: spring
+                }
+            ),
+            Animated.delay(delay),
+            Animated.timing(
+                this.state.snackbarOffset,
+                {
+                    toValue: 0,
+                    duration: spring
+                }
+            )
+        ])
+
+        animation.start()
     }
     renderButton = styles => (
         <Animated.View style={styles.positionContainer}>


### PR DESCRIPTION
Currently any Snackbar components, cover the action button when they are displayed. This PR adds a method on the ActionButton component to avoid the snackbar.

The example below is used with [react-native-snackbar](https://github.com/cooperka/react-native-snackbar)

It uses a ref on the ActionButton to call the method.

The properties are:

| prop | description |
| -- | -- |
| spring | time for spring action |
| delay | time in between going up and coming down |
| height | Amount of space to go up by |
 
E.g
```jsx
this.refs.action.avoidSnackbar({
  spring: 200, 
  delay: 2800,
  height: 40
})


<ActionButton ref="action"/>
```

### Before
![fab avoid snackbar - before](https://cloud.githubusercontent.com/assets/5962998/26327264/aca9bce0-3f0c-11e7-9207-f77b671c95d3.gif)


### After
![fab avoid snackbar](https://cloud.githubusercontent.com/assets/5962998/26327005/a4690b86-3f0b-11e7-9732-a39738e5b701.gif)
