### PR TITLE
Add support for toggling animated background rendering

### DIFF
--- a/src/Toolbar/Toolbar.react.js
+++ b/src/Toolbar/Toolbar.react.js
@@ -140,11 +140,16 @@ const propTypes = {
     * Called when rightElement was pressed.
     */
     onRightElementPress: PropTypes.func,
+    /**
+    * Toggle animated background rendering
+    */
+    showAnimatedBackground: PropTypes.bool,
 };
 const defaultProps = {
     elevation: 4, // TODO: probably useless, elevation is defined in getTheme function
     style: {},
     hidden: false,
+    showAnimatedBackground: true,
 };
 const contextTypes = {
     uiTheme: PropTypes.object.isRequired,
@@ -412,6 +417,7 @@ class Toolbar extends PureComponent {
             onLeftElementPress,
             onPress,
             onRightElementPress,
+            showAnimatedBackground,
         } = this.props;
 
         const { isSearchActive, searchValue } = this.state;
@@ -426,7 +432,7 @@ class Toolbar extends PureComponent {
                     { transform: [{ translateY: this.state.positionValue }] },
                 ]}
             >
-                {this.renderAnimatedBackgrounds(styles)}
+                {showAnimatedBackground && this.renderAnimatedBackgrounds(styles)}
                 <LeftElement
                     {...this.props}
                     onLeftElementPress={onLeftElementPress}


### PR DESCRIPTION
Presently, the animated background is rendered by default even when the search bar is not being used. This prevents `container` styles like borderRadius from taking effect as borderRadius is recalculated in the animated background overlay.

This PR is a more like straightforward solution although it might make sense to use the borderRadius from props in animated background whenever it's present.

@xotahal Please, check that this is in line with the vision of the package. Thanks