### PR TITLE
properly close the search on updates

### DIFF
--- a/src/Toolbar/CenterElement.react.js
+++ b/src/Toolbar/CenterElement.react.js
@@ -102,7 +102,7 @@ class CenterElement extends PureComponent {
         //    object again to this instance, search text and isSearchActive will be still set
         let content = null;
 
-        if (isSearchActive) {
+        if (searchable && isSearchActive) {
             content = (
                 <TextInput
                     ref={(ref) => { this.searchFieldRef = ref; }}

--- a/src/Toolbar/Toolbar.react.js
+++ b/src/Toolbar/Toolbar.react.js
@@ -200,6 +200,12 @@ class Toolbar extends PureComponent {
         };
     }
     componentWillReceiveProps(nextProps) {
+        // if search is active and we clicked on the results which does not allow search
+        // then close the previous search.
+        if (this.state.isSearchActive && !nextProps.searchable) {
+            this.onSearchCloseRequested();
+        }
+
         // there should be also posibility to change search through props, so we need to check
         // props first and then we should check state if we need to change search state
         if (this.props.isSearchActive !== nextProps.isSearchActive) {


### PR DESCRIPTION
when search is active and then toolbar updates which disables search, we need to properly close the search bar other wise the app crashes.

cc @xotahal 