### PR TITLE
Fixed bug for missing ViewPropTypes.style

### DIFF
--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -46,7 +46,7 @@ const propTypes = {
     * You can overide any style for this button
     */
     style: PropTypes.shape({
-        container: ViewPropTypes,
+        container: ViewPropTypes.style,
         text: Text.propTypes.style,
     }),
 };


### PR DESCRIPTION
Button's container style prop type should've been ViewPropTypes.style instead of ViewPropTypes

![screen shot 2017-07-24 at 2 32 03 pm](https://user-images.githubusercontent.com/5962998/28538707-33dfb420-707d-11e7-98df-c7ab137411fe.png)
