### PR TITLE
Fix IconToggle in ListItem

### DIFF
--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -359,10 +359,11 @@ class ListItem extends PureComponent {
                 <IconToggle
                     key={action}
                     color={flattenRightElement.color}
+                    name={action}
+                    size={24}
+                    style={styles.rightElement}
                     onPress={() => this.onRightElementPressed({ action })}
-                >
-                    <Icon name={action} size={24} style={styles.rightElement} />
-                </IconToggle>
+                />
             ));
         }
 


### PR DESCRIPTION
The changes in https://github.com/xotahal/react-native-material-ui/commit/4e2b50813ac8f837da5e288a5ef6dc0c289feac1#diff-94989ecb7ebebf42e6f88f836eb60698 broke the ListItem component and it now shows a warning.

![simulator screen shot jul 28 2017 12 54 16 pm](https://user-images.githubusercontent.com/5962998/28728039-1c188716-7395-11e7-803c-415c22ccdcb7.png)

This PR makes the name property optional