### PR TITLE
[RadioButton]: Use onPress function from RadioButton

### DIFF
--- a/src/RadioButton/RadioButton.react.js
+++ b/src/RadioButton/RadioButton.react.js
@@ -33,6 +33,7 @@ class RadioButton extends PureComponent {
             <Checkbox
                 checkedIcon="radio-button-checked"
                 uncheckedIcon="radio-button-unchecked"
+                onCheck={this.onPress}
                 {...this.props}
             />
         );


### PR DESCRIPTION
The `RadioButton` is expecting `onSelect` and is not using it currently. It only works if we pass down `onCheck` to props as `Checkbox` uses that.