### PR TITLE
Searchable prop optional

### DIFF
--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -25,6 +25,7 @@ const defaultProps = {
     onRightElementPress: null,
     size: null,
     style: {},
+    searchable: null,
 };
 const contextTypes = {
     uiTheme: PropTypes.object.isRequired,

--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -12,7 +12,7 @@ const UIManager = NativeModules.UIManager;
 const propTypes = {
     isSearchActive: PropTypes.bool.isRequired,
     searchValue: PropTypes.string.isRequired,
-    searchable: PropTypes.object.isRequired,
+    searchable: PropTypes.object,
     style: PropTypes.object,
     size: PropTypes.number,
     rightElement: PropTypes.any,


### PR DESCRIPTION
Currently just using the Toolbar with throws a proptypes error for the `searchable` prop on `RightElement`. This PR makes the searchable prop optional on the RightElement component