### PR TITLE
Fix misplaced ripple effect

### DIFF
--- a/src/ActionButton/ActionButton.react.js
+++ b/src/ActionButton/ActionButton.react.js
@@ -400,7 +400,7 @@ class ActionButton extends PureComponent {
             result = <Icon name={icon} style={styles.icon} />;
         }
         return (
-            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }} pointerEvents='box-only'>
                 {result}
             </View>
         );

--- a/src/BottomNavigation/BottomNavigationAction.react.js
+++ b/src/BottomNavigation/BottomNavigationAction.react.js
@@ -107,7 +107,7 @@ class BottomNavigationAction extends PureComponent {
 
         return (
             <RippleFeedback onPress={onPress}>
-                <View style={styles.container}>
+                <View style={styles.container} pointerEvents='box-only'>
                     {iconElement}
                     <Text style={styles.label}>{label}</Text>
                 </View>

--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -189,7 +189,7 @@ class Button extends PureComponent {
         const styles = getStyles(this.props, this.context, this.state);
 
         const content = (
-            <View style={styles.container}>
+            <View style={styles.container} pointerEvents='box-only'>
                 {this.renderIcon(styles)}
                 <Text style={styles.text}>
                     {upperCase ? text.toUpperCase() : text}

--- a/src/Card/Card.react.js
+++ b/src/Card/Card.react.js
@@ -53,7 +53,7 @@ class Card extends PureComponent {
 
         if (onPress) {
             return (
-                <RippleFeedback onPress={onPress}>
+                <RippleFeedback onPress={onPress} pointerEvents='box-only'>
                     {content}
                 </RippleFeedback>
             );

--- a/src/Checkbox/Checkbox.react.js
+++ b/src/Checkbox/Checkbox.react.js
@@ -90,7 +90,7 @@ class Checkbox extends PureComponent {
         const iconColor = StyleSheet.flatten(styles.icon).color;
 
         const content = (
-            <View style={styles.container}>
+            <View style={styles.container} pointerEvents='box-only'>
                 <IconToggle
                     key={`${value}-${checked}`}
                     name={checked ? checkedIcon : uncheckedIcon}

--- a/src/Dialog/Dialog.react.js
+++ b/src/Dialog/Dialog.react.js
@@ -41,7 +41,7 @@ class Dialog extends PureComponent {
 
         return (
             <RippleFeedback onPress={onPress} >
-                <View style={styles.container}>
+                <View style={styles.container} pointerEvents='box-only'>
                     {children}
                 </View>
             </RippleFeedback>

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -410,7 +410,7 @@ class ListItem extends PureComponent {
         return <Divider />;
     }
     renderContent = styles => (
-        <View style={styles.contentViewContainer}>
+        <View style={styles.contentViewContainer} pointerEvents='box-only'>
             {this.renderLeftElement(styles)}
             {this.renderCenterElement(styles)}
             {this.renderRightElement(styles)}


### PR DESCRIPTION
Fixes misplaced ripple effect, while touching element. 
Source: https://github.com/facebook/react-native/issues/6139

| Before        | After           |
| ------------- |:-------------:|
|![before](https://user-images.githubusercontent.com/616857/29894648-b760bc3a-8dde-11e7-8b1a-c2f0053012aa.gif)     |![after](https://user-images.githubusercontent.com/616857/29894651-b9d637a6-8dde-11e7-9572-f0fdd472ec8f.gif) |

P.S. Unfortunately, I failed to move changes to only one place, so let me know if I can improve this PR.