### PR TITLE
Toolbar search without leftElement shows forward icon

### DIFF
--- a/src/Toolbar/LeftElement.react.js
+++ b/src/Toolbar/LeftElement.react.js
@@ -89,7 +89,7 @@ class LeftElement extends PureComponent {
             easing: Easing.linear,
             useNativeDriver: Platform.OS === 'android',
         }).start(() => {
-            let leftElement = activate ? SEARCH_FORWARD_ICON : this.props.leftElement;
+            const leftElement = activate ? SEARCH_FORWARD_ICON : this.props.leftElement;
 
             this.setState({ leftElement });
 

--- a/src/Toolbar/LeftElement.react.js
+++ b/src/Toolbar/LeftElement.react.js
@@ -28,7 +28,6 @@ const contextTypes = {
 };
 
 const SEARCH_BACK_ICON = 'arrow-back';
-const SEARCH_FORWARD_ICON = 'arrow-forward';
 
 function shouldUpdateStyles(props, nextProps) {
     if (props.style !== nextProps.styles) {
@@ -64,7 +63,7 @@ class LeftElement extends PureComponent {
 
         this.state = {
             styles: getStyles(this.props, this.context),
-            leftElement: props.isSearchActive ? SEARCH_FORWARD_ICON : props.leftElement,
+            leftElement: props.isSearchActive ? SEARCH_BACK_ICON : props.leftElement,
             spinValue: new Animated.Value(props.isSearchActive ? 1 : 0),
         };
     }
@@ -90,12 +89,7 @@ class LeftElement extends PureComponent {
             easing: Easing.linear,
             useNativeDriver: Platform.OS === 'android',
         }).start(() => {
-            let leftElement = activate ? SEARCH_FORWARD_ICON : this.props.leftElement;
-
-            if (!this.state.leftElement) {
-                // because there won't be animation in this case
-                leftElement = SEARCH_BACK_ICON;
-            }
+            let leftElement = activate ? SEARCH_BACK_ICON : this.props.leftElement;
 
             this.setState({ leftElement });
 

--- a/src/Toolbar/LeftElement.react.js
+++ b/src/Toolbar/LeftElement.react.js
@@ -27,7 +27,7 @@ const contextTypes = {
     uiTheme: PropTypes.object.isRequired,
 };
 
-const SEARCH_BACK_ICON = 'arrow-back';
+const SEARCH_FORWARD_ICON = 'arrow-forward';
 
 function shouldUpdateStyles(props, nextProps) {
     if (props.style !== nextProps.styles) {
@@ -63,7 +63,7 @@ class LeftElement extends PureComponent {
 
         this.state = {
             styles: getStyles(this.props, this.context),
-            leftElement: props.isSearchActive ? SEARCH_BACK_ICON : props.leftElement,
+            leftElement: props.isSearchActive ? SEARCH_FORWARD_ICON : props.leftElement,
             spinValue: new Animated.Value(props.isSearchActive ? 1 : 0),
         };
     }
@@ -89,7 +89,7 @@ class LeftElement extends PureComponent {
             easing: Easing.linear,
             useNativeDriver: Platform.OS === 'android',
         }).start(() => {
-            let leftElement = activate ? SEARCH_BACK_ICON : this.props.leftElement;
+            let leftElement = activate ? SEARCH_FORWARD_ICON : this.props.leftElement;
 
             this.setState({ leftElement });
 


### PR DESCRIPTION
It should show back icon instead of forward icon.

Current design:
<img width="465" alt="screen shot 2017-08-31 at 12 59 53" src="https://user-images.githubusercontent.com/4710865/29920155-76aff0d4-8e4c-11e7-8077-4763163b2f7d.png">

![29116772-270cae78-7d26-11e7-943a-3ca4b93a9612](https://user-images.githubusercontent.com/4710865/31173517-219d55e2-a908-11e7-8643-1712a0a21a25.gif)
