### PR TITLE
Add ripple color option for action button

### DIFF
--- a/src/ActionButton/ActionButton.react.js
+++ b/src/ActionButton/ActionButton.react.js
@@ -57,6 +57,10 @@ const propTypes = {
     */
     transition: PropTypes.oneOf(['toolbar', 'speedDial']),
     /**
+    * Set ripple color
+    */
+    rippleColor: PropTypes.string,
+    /**
     * You can overide any style for this button
     */
     style: PropTypes.shape({
@@ -72,6 +76,7 @@ const defaultProps = {
     icon: 'add',
     style: {},
     hidden: false,
+    rippleColor: '#AAF',
 };
 const contextTypes = {
     uiTheme: PropTypes.object.isRequired,
@@ -298,7 +303,7 @@ class ActionButton extends PureComponent {
         return (
             <View key="main-button" style={styles.container}>
                 <RippleFeedback
-                    color="#AAF"
+                    color={this.props.rippleColor}
                     onPress={() => this.onPress('main-button')}
                     onLongPress={onLongPress}
                     onPressIn={() => this.setState({ elevation: 4 })}
@@ -317,7 +322,7 @@ class ActionButton extends PureComponent {
         if (React.isValidElement(icon)) {
             content = (
                 <RippleFeedback
-                    color="#AAF"
+                    color={this.props.rippleColor}
                     onPress={() => this.onPress(key)}
                     delayPressIn={20}
                 >
@@ -363,7 +368,7 @@ class ActionButton extends PureComponent {
             <View key={key} style={styles.speedDialActionIconContainer}>
                 <View style={styles.speedDialActionIcon}>
                     <RippleFeedback
-                        color="#AAF"
+                        color={this.props.rippleColor}
                         onPress={() => this.onPress(key)}
                         delayPressIn={20}
                     >


### PR DESCRIPTION
Current implementation of action button has hardcoded ripple color. I would like to provide a prop to change it.