### PR TITLE
Icons: use PropTypes.any on style props to support Stylesheet declarations

### DIFF
--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     name: PropTypes.string.isRequired,
-    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    style: PropTypes.any,
     size: PropTypes.number,
     color: PropTypes.string,
 };


### PR DESCRIPTION
Why? React native throws warning when referencing a stylesheet object property to the Icon style prop. 
We can only use this
`<Icon name="location" size={20} color="#fff" style={{width: 50, height: 50}} />`

But throws a warning for this
`<Icon name="location" size={20} color="#fff" style={styles.iconSet} />`

~ `react-native-vector-icons` use the same proptype validation for the icon set, style prop. Unless we would like to use the `View.PropTypes.style` or `Text.PropTypes.style`. That'll require to import them from react-native