### PR TITLE
Fix list item subview clicks

### DIFF
--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -426,13 +426,16 @@ class ListItem extends PureComponent {
 
         return <Divider />;
     }
-    renderContent = styles => (
-        <View style={styles.contentViewContainer} pointerEvents="box-only">
-            {this.renderLeftElement(styles)}
-            {this.renderCenterElement(styles)}
-            {this.renderRightElement(styles)}
-        </View>
-    )
+    renderContent = (styles) => {
+        const pointerEvents = this.props.rightElement ? 'auto' : 'box-only';
+        return (
+            <View style={styles.contentViewContainer} pointerEvents={pointerEvents}>
+                {this.renderLeftElement(styles)}
+                {this.renderCenterElement(styles)}
+                {this.renderRightElement(styles)}
+            </View>
+        );
+    }
     render() {
         const { onPress, onLongPress } = this.props;
 

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -446,7 +446,11 @@ class ListItem extends PureComponent {
 
         if (onPress || onLongPress) {
             content = (
-                <RippleFeedback delayPressIn={50} onPress={this.onListItemPressed} onLongPress={this.onListItemLongPressed} >
+                <RippleFeedback
+                    delayPressIn={50}
+                    onPress={this.onListItemPressed}
+                    onLongPress={this.onListItemLongPressed}
+                >
                     {content}
                 </RippleFeedback>
             );

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -269,6 +269,15 @@ class ListItem extends PureComponent {
             onRightElementPress(onPressValue);
         }
     };
+    getPointerEvents = () => {
+        // 'box-only' fixes misplaced ripple effect, but ruins click events for subviews.
+        // It's suitable only for simple cases with no touchable views, except the main one.
+        const { onLeftElementPress, leftElement, centerElement, rightElement } = this.props;
+        return onLeftElementPress ||
+            React.isValidElement(leftElement) ||
+            React.isValidElement(centerElement) ||
+            rightElement ? 'auto' : 'box-only';
+    }
     renderLeftElement = (styles) => {
         const { leftElement } = this.props;
 
@@ -426,16 +435,13 @@ class ListItem extends PureComponent {
 
         return <Divider />;
     }
-    renderContent = (styles) => {
-        const pointerEvents = this.props.rightElement ? 'auto' : 'box-only';
-        return (
-            <View style={styles.contentViewContainer} pointerEvents={pointerEvents}>
-                {this.renderLeftElement(styles)}
-                {this.renderCenterElement(styles)}
-                {this.renderRightElement(styles)}
-            </View>
-        );
-    }
+    renderContent = styles => (
+        <View style={styles.contentViewContainer} pointerEvents={this.getPointerEvents()}>
+            {this.renderLeftElement(styles)}
+            {this.renderCenterElement(styles)}
+            {this.renderRightElement(styles)}
+        </View>
+    )
     render() {
         const { onPress, onLongPress } = this.props;
 


### PR DESCRIPTION
This PR fixes right element click, which I previously ruined with #195 (sorry for the regression!)
Basically, it returns default `pointerEvents` prop value to the `ListItem` view when the right element is present. Otherwise, it will be `box-only`.

Unfortunately, I cannot find more elegant solution right now.