### PR TITLE
Create getPlatformElevation.windows.js

### DIFF
--- a/src/styles/getPlatformElevation.windows.js
+++ b/src/styles/getPlatformElevation.windows.js
@@ -1,0 +1,4 @@
+
+const getPlatformElevation = elevation => ({ elevation });
+
+export default getPlatformElevation;


### PR DESCRIPTION
Fix "error: bundling failed: UnableToResolveError: Unable to resolve module `./getPlatformElevation` " to be compatible with react-native-windows