### PR TITLE
Allow the default menu icon to be overwritten as the props would suggest

### DIFF
--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -402,7 +402,7 @@ class ListItem extends PureComponent {
                         }}
                     />
                     <IconToggle
-                        name={rightElement.menu.icon || "more-vert"}
+                        name={rightElement.menu.icon || 'more-vert'}
                         color={flattenRightElement.color}
                         onPress={() => this.onMenuPressed(rightElement.menu.labels)}
                         style={flattenRightElement}
@@ -443,7 +443,11 @@ class ListItem extends PureComponent {
 
         if (onPress || onLongPress) {
             content = (
-                <RippleFeedback delayPressIn={50} onPress={this.onListItemPressed} onLongPress={this.onListItemLongPressed} >
+                <RippleFeedback 
+                    delayPressIn={50}
+                    onPress={this.onListItemPressed}
+                    onLongPress={this.onListItemLongPressed}
+                >
                     {content}
                 </RippleFeedback>
             );

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -443,7 +443,7 @@ class ListItem extends PureComponent {
 
         if (onPress || onLongPress) {
             content = (
-                <RippleFeedback 
+                <RippleFeedback
                     delayPressIn={50}
                     onPress={this.onListItemPressed}
                     onLongPress={this.onListItemLongPressed}

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -402,7 +402,7 @@ class ListItem extends PureComponent {
                         }}
                     />
                     <IconToggle
-                        name="more-vert"
+                        name={rightElement.menu.icon || "more-vert"}
                         color={flattenRightElement.color}
                         onPress={() => this.onMenuPressed(rightElement.menu.labels)}
                         style={flattenRightElement}

--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -180,7 +180,7 @@ class RightElement extends PureComponent {
                         }}
                     />
                     <IconToggle
-                        name={rightElement.menu.icon || "more-vert"}
+                        name={rightElement.menu.icon || 'more-vert'}
                         color={flattenRightElement.color}
                         size={size}
                         onPress={() => this.onMenuPressed(rightElement.menu.labels)}

--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -131,6 +131,30 @@ class RightElement extends PureComponent {
             result.push(React.cloneElement(rightElement, { key: 'customRightElement' }));
         }
 
+        if (rightElement && rightElement.menu && !isSearchActive) {
+            result.push(
+                <View key="menuIcon">
+                    {/* We need this view as an anchor for drop down menu. findNodeHandle can
+                        find just view with width and height, even it needs backgroundColor :/
+                    */}
+                    <View
+                        ref={(c) => { this.menu = c; }}
+                        style={{
+                            backgroundColor: 'transparent',
+                            width: 1,
+                            height: StyleSheet.hairlineWidth,
+                        }}
+                    />
+                    <IconToggle
+                        name={rightElement.menu.icon || "more-vert"}
+                        color={flattenRightElement.color}
+                        size={size}
+                        onPress={() => this.onMenuPressed(rightElement.menu.labels)}
+                        style={flattenRightElement}
+                    />
+                </View>,
+            );
+        }
 
         // if searchable feature is on and search is active with some text, then we show clear
         // button, to be able to clear text
@@ -163,31 +187,6 @@ class RightElement extends PureComponent {
                     />,
                 );
             }
-        }
-
-        if (rightElement && rightElement.menu && !isSearchActive) {
-            result.push(
-                <View key="menuIcon">
-                    {/* We need this view as an anchor for drop down menu. findNodeHandle can
-                        find just view with width and height, even it needs backgroundColor :/
-                    */}
-                    <View
-                        ref={(c) => { this.menu = c; }}
-                        style={{
-                            backgroundColor: 'transparent',
-                            width: 1,
-                            height: StyleSheet.hairlineWidth,
-                        }}
-                    />
-                    <IconToggle
-                        name={rightElement.menu.icon || "more-vert"}
-                        color={flattenRightElement.color}
-                        size={size}
-                        onPress={() => this.onMenuPressed(rightElement.menu.labels)}
-                        style={flattenRightElement}
-                    />
-                </View>,
-            );
         }
 
         return (

--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -131,30 +131,6 @@ class RightElement extends PureComponent {
             result.push(React.cloneElement(rightElement, { key: 'customRightElement' }));
         }
 
-        if (rightElement && rightElement.menu && !isSearchActive) {
-            result.push(
-                <View key="menuIcon">
-                    {/* We need this view as an anchor for drop down menu. findNodeHandle can
-                        find just view with width and height, even it needs backgroundColor :/
-                    */}
-                    <View
-                        ref={(c) => { this.menu = c; }}
-                        style={{
-                            backgroundColor: 'transparent',
-                            width: 1,
-                            height: StyleSheet.hairlineWidth,
-                        }}
-                    />
-                    <IconToggle
-                        name={rightElement.menu.icon || "more-vert"}
-                        color={flattenRightElement.color}
-                        size={size}
-                        onPress={() => this.onMenuPressed(rightElement.menu.labels)}
-                        style={flattenRightElement}
-                    />
-                </View>,
-            );
-        }
 
         // if searchable feature is on and search is active with some text, then we show clear
         // button, to be able to clear text
@@ -187,6 +163,31 @@ class RightElement extends PureComponent {
                     />,
                 );
             }
+        }
+
+        if (rightElement && rightElement.menu && !isSearchActive) {
+            result.push(
+                <View key="menuIcon">
+                    {/* We need this view as an anchor for drop down menu. findNodeHandle can
+                        find just view with width and height, even it needs backgroundColor :/
+                    */}
+                    <View
+                        ref={(c) => { this.menu = c; }}
+                        style={{
+                            backgroundColor: 'transparent',
+                            width: 1,
+                            height: StyleSheet.hairlineWidth,
+                        }}
+                    />
+                    <IconToggle
+                        name={rightElement.menu.icon || "more-vert"}
+                        color={flattenRightElement.color}
+                        size={size}
+                        onPress={() => this.onMenuPressed(rightElement.menu.labels)}
+                        style={flattenRightElement}
+                    />
+                </View>,
+            );
         }
 
         return (

--- a/src/Toolbar/RightElement.react.js
+++ b/src/Toolbar/RightElement.react.js
@@ -180,7 +180,7 @@ class RightElement extends PureComponent {
                         }}
                     />
                     <IconToggle
-                        name="more-vert"
+                        name={rightElement.menu.icon || "more-vert"}
                         color={flattenRightElement.color}
                         size={size}
                         onPress={() => this.onMenuPressed(rightElement.menu.labels)}


### PR DESCRIPTION
Currently the default Toolbar menu button's icon can't be overwritten, despite the menu.icon props suggesting that I should be. This PR would fix the issue.