### PR TITLE
Fix shadow props on iOS

### DIFF
--- a/src/styles/getPlatformElevation.ios.js
+++ b/src/styles/getPlatformElevation.ios.js
@@ -1,23 +1,20 @@
 /* eslint-enable import/no-unresolved, import/extensions */
-import { black } from './colors';
+import { black, transparent } from './colors';
 import { ELEVATION_ZINDEX } from './constants';
 
 const getPlatformElevation = (elevation) => {
-    if (elevation !== 0) {
-        return {
-            shadowColor: black,
-            shadowOpacity: 0.3,
-            shadowRadius: elevation,
-            shadowOffset: {
-                height: 2,
-                width: 0,
-            },
-            // we need to have zIndex on iOS, otherwise the shadow is under components that
-            // are rendered later
-            zIndex: ELEVATION_ZINDEX,
-        };
-    }
-    return { };
+    return {
+        shadowColor: elevation > 0 ? black : transparent,
+        shadowOpacity: 0.3,
+        shadowRadius: elevation / 2,
+        shadowOffset: {
+            height: 1,
+            width: 0,
+        },
+        // we need to have zIndex on iOS, otherwise the shadow is under components that
+        // are rendered later
+        zIndex: ELEVATION_ZINDEX,
+    };
 };
 
 export default getPlatformElevation;


### PR DESCRIPTION
I think the shadow radius should be divided by 2 and the offset height should be 1. We should also reset the shadow color to transparent if there is no elevation.
And also it should be possible to set the elevation to 0. Currently it cannot be set to 0 e. g. for _Card_ component because it's always overwritten with theme styles which set the shadows.

Results:
<img width="657" alt="screen shot 2017-11-14 at 1 20 05 pm" src="https://user-images.githubusercontent.com/4710865/32780067-4ea3bf06-c940-11e7-8754-3d6e79f0eb16.png">
<img width="668" alt="screen shot 2017-11-14 at 1 20 50 pm" src="https://user-images.githubusercontent.com/4710865/32780069-4ed5a8ea-c940-11e7-8309-fc750fa3f231.png">
