### PR TITLE
Fix iOS zero elevation zIndex

### DIFF
--- a/src/styles/getPlatformElevation.ios.js
+++ b/src/styles/getPlatformElevation.ios.js
@@ -7,7 +7,7 @@ const getPlatformElevation = (elevation) => {
         return {
             shadowColor: transparent,
             zIndex: 0,
-        }
+        };
     }
 
     return {

--- a/src/styles/getPlatformElevation.ios.js
+++ b/src/styles/getPlatformElevation.ios.js
@@ -3,8 +3,15 @@ import { black, transparent } from './colors';
 import { ELEVATION_ZINDEX } from './constants';
 
 const getPlatformElevation = (elevation) => {
+    if (elevation === 0) {
+        return {
+            shadowColor: transparent,
+            zIndex: 0,
+        }
+    }
+
     return {
-        shadowColor: elevation > 0 ? black : transparent,
+        shadowColor: black,
         shadowOpacity: 0.3,
         shadowRadius: elevation / 2,
         shadowOffset: {


### PR DESCRIPTION
The zIndex should be 0 if there is no elevation.