### PR TITLE
fix default size for a badge

### DIFF
--- a/src/Badge/Badge.react.js
+++ b/src/Badge/Badge.react.js
@@ -45,7 +45,7 @@ const defaultProps = {
     children: null,
     text: null,
     icon: null,
-    size: 4,
+    size: 16,
     stroke: null,
     style: {
         container: {


### PR DESCRIPTION
This commit(https://github.com/xotahal/react-native-material-ui/commit/4e2b50813ac8f837da5e288a5ef6dc0c289feac1) changed the default badge size to 4 which breaks because by default in the style we set the width to 16(https://github.com/xotahal/react-native-material-ui/blob/master/src/styles/getTheme.js#L123).
Also the container is set to use top: -8 which is 16/2.

This restores the previous behavior and ensures that badge is visible when size is not provided.

cc @xotahal 