### PR TITLE
Children in cards might receive input. and fixed backwards compatibility.

### DIFF
--- a/src/Card/Card.react.js
+++ b/src/Card/Card.react.js
@@ -56,7 +56,7 @@ class Card extends PureComponent {
         const { styles } = this.state;
 
         return (
-            <View style={styles.container} pointerEvents={onPress ? 'box-only' : 'box-none'}>
+            <View style={styles.container} pointerEvents='auto'>
                 {children}
             </View>
         );

--- a/src/Card/Card.react.js
+++ b/src/Card/Card.react.js
@@ -52,11 +52,11 @@ class Card extends PureComponent {
     }
 
     renderContent = () => {
-        const { children, onPress } = this.props;
+        const { children } = this.props;
         const { styles } = this.state;
 
         return (
-            <View style={styles.container} pointerEvents='auto'>
+            <View style={styles.container} pointerEvents="auto">
                 {children}
             </View>
         );

--- a/src/Card/Card.react.js
+++ b/src/Card/Card.react.js
@@ -56,7 +56,7 @@ class Card extends PureComponent {
         const { styles } = this.state;
 
         return (
-            <View style={styles.container} pointerEvents={onPress ? "box-only" : "box-none"}>
+            <View style={styles.container} pointerEvents={onPress ? 'box-only' : 'box-none'}>
                 {children}
             </View>
         );

--- a/src/Card/Card.react.js
+++ b/src/Card/Card.react.js
@@ -50,16 +50,18 @@ class Card extends PureComponent {
             styles: getStyles(props, context),
         };
     }
+
     renderContent = () => {
-        const { children } = this.props;
+        const { children, onPress } = this.props;
         const { styles } = this.state;
 
         return (
-            <View style={styles.container} pointerEvents="box-only">
+            <View style={styles.container} pointerEvents={onPress ? "box-only" : "box-none"}>
                 {children}
             </View>
         );
     }
+
     render() {
         const { onPress } = this.props;
 

--- a/src/RippleFeedback/RippleFeedbackAndroid.react.js
+++ b/src/RippleFeedback/RippleFeedbackAndroid.react.js
@@ -27,7 +27,7 @@ class RippleFeedback extends PureComponent {
         // TouchableNativeFeedback.Ripple function on iOS devices
         const mapProps = { ...otherProps };
 
-        if (color) {
+        if (color && Platform.Version >= 21) {
             mapProps.background = TouchableNativeFeedback.Ripple(color, borderless);
         }
 

--- a/src/RippleFeedback/RippleFeedbackAndroid.react.js
+++ b/src/RippleFeedback/RippleFeedbackAndroid.react.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved, import/extensions */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { TouchableNativeFeedback } from 'react-native';
+import { TouchableNativeFeedback, Platform } from 'react-native';
 /* eslint-enable import/no-unresolved, import/extensions */
 
 const propTypes = {


### PR DESCRIPTION
7701dee00dbdfc8ba4006d1bd43d5f8919f11290 fixed styling issues with the ripple. It also introduced a bug where if the card had children that were buttons or other elements that could receive input they would never receive the input.

This checks whether the Card has an onPress, and if it does set the pointerEvents to 'box-only', else set it to 'box-none'. 'box-only' implies that only the view itself can receive input, and no children. 'box-none' implies that the view itself won't receive input, and only the children.