### PR TITLE
fix: autoCapitalize is a string

### DIFF
--- a/src/Toolbar/CenterElement.react.js
+++ b/src/Toolbar/CenterElement.react.js
@@ -10,7 +10,7 @@ const propTypes = {
     searchValue: PropTypes.string.isRequired,
     searchable: PropTypes.shape({
         autoFocus: PropTypes.bool,
-        autoCapitalize: PropTypes.string,
+        autoCapitalize: TextInput.propTypes.autoCapitalize,
         autoCorrect: PropTypes.bool,
         onChangeText: PropTypes.func,
         onSubmitEditing: PropTypes.func,

--- a/src/Toolbar/CenterElement.react.js
+++ b/src/Toolbar/CenterElement.react.js
@@ -10,7 +10,7 @@ const propTypes = {
     searchValue: PropTypes.string.isRequired,
     searchable: PropTypes.shape({
         autoFocus: PropTypes.bool,
-        autoCapitalize: PropTypes.bool,
+        autoCapitalize: PropTypes.string,
         autoCorrect: PropTypes.bool,
         onChangeText: PropTypes.func,
         onSubmitEditing: PropTypes.func,


### PR DESCRIPTION
autoCapitalize can have the following values: 'none', 'sentences', 'words', 'characters'. See https://facebook.github.io/react-native/docs/textinput.html for details.