### PR TITLE
fix for undefined ScrollView.propTypes

### DIFF
--- a/src/Drawer/Drawer.react.js
+++ b/src/Drawer/Drawer.react.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-unresolved, import/extensions */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { ScrollView } from 'react-native';
 import { ViewPropTypes } from '../utils';
 /* eslint-enable import/no-unresolved, import/extensions */
 import Container from '../Container';

--- a/src/Drawer/Drawer.react.js
+++ b/src/Drawer/Drawer.react.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved, import/extensions */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView } from 'react-native';
+import { ViewPropTypes } from '../utils';
 /* eslint-enable import/no-unresolved, import/extensions */
 import Container from '../Container';
 
@@ -11,7 +11,7 @@ import Section from './Section.react';
 const propTypes = {
     children: PropTypes.node.isRequired,
     style: PropTypes.shape({
-        container: ScrollView.propTypes.style,
+        container: ViewPropTypes.style,
     }),
 };
 const defaultProps = {


### PR DESCRIPTION
I'm getting the following error using "react-native": "0.51.0" (copied styles thing from `Dialog/Dialog.react.js`)
```
 FAIL  Tests/Containers/SplashTest.js
  ● Test suite failed to run
    TypeError: Cannot read property 'style' of undefined
      
      at Object.<anonymous> (node_modules/react-native-material-ui/src/Drawer/Drawer.react.js:14:45)
      at Object.<anonymous> (node_modules/react-native-material-ui/src/Drawer/index.js:1:159)
      at Object.<anonymous> (node_modules/react-native-material-ui/src/index.js:17:25)
```