### PR TITLE
Change ActionButton propTypes to allow elements for icons

### DIFF
--- a/src/ActionButton/ActionButton.react.js
+++ b/src/ActionButton/ActionButton.react.js
@@ -50,7 +50,10 @@ const propTypes = {
     /**
     * If specified it'll be shown before text
     */
-    icon: PropTypes.string,
+    icon: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.string,
+    ]),
     /**
     * Leave it empty if you don't want any transition after press. Otherwise, it will be trnasform
     * to another view - depends on transition value.


### PR DESCRIPTION
Currently elements are allowed as ActionButton icons, but the propType only allows strings.