### PR TITLE
Duplicate keys when re-using icons

### DIFF
--- a/src/Drawer/Section.react.js
+++ b/src/Drawer/Section.react.js
@@ -100,7 +100,7 @@ class Section extends PureComponent {
                         return (
                             <ListItem
                                 dense
-                                key={item.icon}
+                                key={item.key ? item.key : item.icon}
                                 leftElement={item.icon}
                                 centerElement={item.value}
                                 onPress={item.onPress}

--- a/src/Drawer/Section.react.js
+++ b/src/Drawer/Section.react.js
@@ -35,6 +35,7 @@ const defaultProps = {
     items: [],
     divider: false,
     style: {},
+    key: '',
 };
 const contextTypes = {
     uiTheme: PropTypes.object.isRequired,

--- a/src/Drawer/Section.react.js
+++ b/src/Drawer/Section.react.js
@@ -28,6 +28,7 @@ const propTypes = {
         value: Text.propTypes.style,
         label: Text.propTypes.style,
     }),
+    key: PropTypes.string,
 };
 const defaultProps = {
     title: null,

--- a/src/Drawer/Section.react.js
+++ b/src/Drawer/Section.react.js
@@ -87,7 +87,7 @@ class Section extends PureComponent {
         const styles = getStyles(this.props, this.context);
 
         return (
-            <View>
+            <View key={this.props.key}>
                 <View style={styles.container}>
                     {this.renderTitle(styles)}
                     {items && items.map((item) => {


### PR DESCRIPTION
It's possible to show a variety of list items with the same icon (`star-border` vs `star` for example). This causes errors and can be avoided by allowing users to specify a key instead of defaulting to the icon.