### PR TITLE
Add list item's minHeight into styles

### DIFF
--- a/src/styles/getTheme.js
+++ b/src/styles/getTheme.js
@@ -389,6 +389,7 @@ export default function getTheme(theme, ...more) {
             container: {
                 backgroundColor: palette.canvasColor,
                 height: 56,
+                minHeight: 40,
             },
             contentViewContainer: {
                 flex: 1,


### PR DESCRIPTION
Because sometimes we need to know what's the height and minHeight of the ListItem.