### PR TITLE
Create index.windows.js

### DIFF
--- a/src/RippleFeedback/index.windows.js
+++ b/src/RippleFeedback/index.windows.js
@@ -1,0 +1,1 @@
+export { default } from './RippleFeedbackWeb.react';


### PR DESCRIPTION
Fix "error: bundling failed: UnableToResolveError: Unable to resolve module ./RippleFeedback" to be compatible with react-native-windows