### PR TITLE
Add onSearchCloseRequested prop

### DIFF
--- a/docs/Toolbar.md
+++ b/docs/Toolbar.md
@@ -39,6 +39,10 @@ const propTypes = {
         */
         onSearchClosed: PropTypes.func,
         /**
+        * Called when action to close search was requested.
+        */
+        onSearchCloseRequested: PropTypes.func,
+        /**
         * Called when search was opened.
         */
         onSearchPressed: PropTypes.func,

--- a/src/Toolbar/Toolbar.react.js
+++ b/src/Toolbar/Toolbar.react.js
@@ -34,6 +34,10 @@ const propTypes = {
         */
         onSearchClosed: PropTypes.func,
         /**
+        * Called when action to close search was requested.
+        */
+        onSearchCloseRequested: PropTypes.func,
+        /**
         * Called when search was opened.
         */
         onSearchPressed: PropTypes.func,
@@ -265,6 +269,10 @@ class Toolbar extends PureComponent {
     * Android's HW/SW back button
     */
     onSearchCloseRequested = () => {
+        if (this.props.searchable.onSearchCloseRequested) {
+            this.props.searchable.onSearchCloseRequested();
+        }
+
         this.setState({
             isSearchActive: false,
             searchValue: '',


### PR DESCRIPTION
### Motivation
Currently with animation, the Toolbar's searchable `onSearchClosed` fires after the animation is complete. However there's no way to get when the user has selected the close action.

This PR introduces the `onSearchCloseRequested` prop to be able to listen that event.

### Example
The example below shows the use of `onSearchClosed` as compared to `onSearchCloseRequested` to clear the input of the searchable.

**Before:**
![on-searched-closed](https://user-images.githubusercontent.com/5962998/37563891-ff546e96-2a60-11e8-9360-039d7361f89c.gif)

**After:**
![on-search-close-requested](https://user-images.githubusercontent.com/5962998/37563892-011cb97c-2a61-11e8-8f99-1a17b7845677.gif)
