### PR TITLE
Make IconToggle name optional - when using children

### DIFF
--- a/src/IconToggle/IconToggle.react.js
+++ b/src/IconToggle/IconToggle.react.js
@@ -34,7 +34,7 @@ const propTypes = {
     /**
     * Name of icon to show
     */
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     /**
     * It'll be used instead of icon (see props name) if exists
     */
@@ -57,6 +57,7 @@ const defaultProps = {
     color: null,
     underlayColor: null,
     size: 24,
+    name: null,
     disabled: false,
     percent: 90,
     maxOpacity: 0.16,


### PR DESCRIPTION
Fixes warning:

![simulator screen shot - iphone 6s - 2018-03-20 at 10 18 16](https://user-images.githubusercontent.com/4710865/37646137-174b8d30-2c29-11e8-8556-a47f87cb6bca.png)
