### PR TITLE
changing scrollview style to contentContainerStyle

### DIFF
--- a/src/Drawer/Drawer.react.js
+++ b/src/Drawer/Drawer.react.js
@@ -26,10 +26,7 @@ function getStyles(props, context) {
     const { drawer } = context.uiTheme;
 
     return {
-        container: [
-            drawer.container,
-            props.style.container,
-        ],
+        container: [drawer.container, props.style.container],
     };
 }
 
@@ -41,7 +38,7 @@ class Drawer extends PureComponent {
 
         return (
             <Container>
-                <ScrollView style={styles.container}>
+                <ScrollView contentContainerStyle={styles.container}>
                     {children}
                 </ScrollView>
             </Container>


### PR DESCRIPTION
Renaming scroll view style prop to `contentContainerStyle` as described in the docs. Style kept throwing an error when passed flex properties