### PR TITLE
Update Dialog.react.js

### DIFF
--- a/src/Dialog/Dialog.react.js
+++ b/src/Dialog/Dialog.react.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved, import/extensions */
-import { View } from 'react-native';
+import { View, TouchableWithoutFeedback } from 'react-native';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 /* eslint-enable import/no-unresolved, import/extensions */
@@ -43,11 +43,11 @@ class Dialog extends PureComponent {
         const styles = getStyles(this.props, this.context);
 
         return (
-            <RippleFeedback onPress={onPress}>
+            <TouchableWithoutFeedback onPress={onPress}>
                 <View style={styles.container}>
                     {children}
                 </View>
-            </RippleFeedback>
+            </TouchableWithoutFeedback>
         );
     }
 }

--- a/src/Dialog/Dialog.react.js
+++ b/src/Dialog/Dialog.react.js
@@ -3,7 +3,6 @@ import { View, TouchableWithoutFeedback } from 'react-native';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 /* eslint-enable import/no-unresolved, import/extensions */
-import RippleFeedback from '../RippleFeedback';
 import { ViewPropTypes } from '../utils';
 
 import Title from './Title.react';


### PR DESCRIPTION
This change will remove the ripple effect from the dialog. I believe the material design 2.0 that has been released recently does not say anything about the ripple effect on the dialog component. I have already asked for this change but it was not done earlier. And  this will take care of the input from the dialog.