### PR TITLE
Allow user to define ListItem's number of lines as an object

### DIFF
--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -137,22 +137,32 @@ function getNumberOfLines(props) {
 /**
 * Please see this: https://material.google.com/components/lists.html#lists-specs
 */
-function getListItemHeight(props, state) {
+function getListItemHeight(props, context, state) {
     const { leftElement, dense } = props;
     const { numberOfLines } = state;
+    const { listItem } = context.uiTheme;
 
     if (numberOfLines === 'dynamic') {
         return null;
     }
 
     if (numberOfLines && typeof numberOfLines === 'object') {
-        const totalNumberOfLines =
-            (numberOfLines.primaryText || 0) +
-            (numberOfLines.secondaryText || 0) +
-            (numberOfLines.tertiaryText || 0);
+        const { primaryText, secondaryText, tertiaryText } = numberOfLines;
         const baseHeight = dense ? 48 : 56;
 
-        return baseHeight + (totalNumberOfLines * 16);
+        return baseHeight +
+            ((primaryText || 0) * StyleSheet.flatten([
+                listItem.primaryText,
+                props.style.primaryText,
+            ]).fontSize) +
+            ((secondaryText || 0) * StyleSheet.flatten([
+                listItem.secondaryText,
+                props.style.secondaryText,
+            ]).fontSize) +
+            ((tertiaryText || 0) * StyleSheet.flatten([
+                listItem.tertiaryText,
+                props.style.tertiaryText,
+            ]).fontSize);
     }
 
     if (!leftElement && numberOfLines === 1) {
@@ -175,7 +185,7 @@ function getStyles(props, context, state) {
     const { numberOfLines } = state;
 
     const container = {
-        height: getListItemHeight(props, state),
+        height: getListItemHeight(props, context, state),
     };
 
     const contentViewContainer = {};

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -31,7 +31,15 @@ const propTypes = {
     * Called when list item is long pressed.
     */
     onLongPress: PropTypes.func,
-    numberOfLines: PropTypes.oneOf([1, 2, 3, 'dynamic']),
+    numberOfLines: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string,
+        PropTypes.shape({
+            primaryText: PropTypes.number,
+            secondaryText: PropTypes.number,
+            tertiaryText: PropTypes.number,
+        }),
+    ]),
     style: PropTypes.shape({
         container: ViewPropTypes.style,
         contentViewContainer: ViewPropTypes.style,
@@ -112,6 +120,10 @@ function getNumberOfSecondaryTextLines(numberOfLines) {
 function getNumberOfLines(props) {
     const { numberOfLines, centerElement } = props;
 
+    if (numberOfLines && typeof numberOfLines === 'object') {
+        return numberOfLines;
+    }
+
     if (centerElement && centerElement.secondaryText && centerElement.tertiaryText
         && (!numberOfLines || numberOfLines < 3)) {
         return 3;
@@ -133,6 +145,16 @@ function getListItemHeight(props, state) {
         return null;
     }
 
+    if (numberOfLines && typeof numberOfLines === 'object') {
+        const totalNumberOfLines =
+            (numberOfLines.primaryText || 0) +
+            (numberOfLines.secondaryText || 0) +
+            (numberOfLines.tertiaryText || 0);
+        const baseHeight = dense ? 48 : 56;
+
+        return baseHeight + (totalNumberOfLines * 16);
+    }
+
     if (!leftElement && numberOfLines === 1) {
         return dense ? 40 : 48;
     }
@@ -152,10 +174,10 @@ function getStyles(props, context, state) {
     const { listItem } = context.uiTheme;
     const { numberOfLines } = state;
 
-
     const container = {
         height: getListItemHeight(props, state),
     };
+
     const contentViewContainer = {};
     const leftElementContainer = {};
     const centerElementContainer = {};
@@ -340,8 +362,8 @@ class ListItem extends PureComponent {
         );
     }
     renderCenterElement = (styles) => {
-        const { centerElement } = this.props;
-        const numberOfLines = getNumberOfSecondaryTextLines(this.state.numberOfLines);
+        const { centerElement, numberOfLines } = this.props;
+        const numberOfSecondaryTextLines = getNumberOfSecondaryTextLines(this.state.numberOfLines);
         let content = null;
 
         if (React.isValidElement(centerElement)) {
@@ -360,13 +382,22 @@ class ListItem extends PureComponent {
                 tertiaryText = centerElement.tertiaryText;
                 /* eslint-enable prefer-destructuring */
             }
-            const secondLineNumber = !tertiaryText ? numberOfLines : 1;
-            const thirdLineNumber = tertiaryText ? numberOfLines : 1;
+
+            let firstLineNumber = 1;
+            let secondLineNumber = !tertiaryText ? numberOfSecondaryTextLines : 1;
+            let thirdLineNumber = tertiaryText ? numberOfSecondaryTextLines : 1;
+
+            if (numberOfLines && typeof numberOfLines === 'object') {
+                firstLineNumber = numberOfLines.primaryText;
+                secondLineNumber = numberOfLines.secondaryText;
+                thirdLineNumber = numberOfLines.tertiaryText;
+            }
+
             content = (
                 <View style={styles.textViewContainer}>
                     <View style={styles.firstLine}>
                         <View style={styles.primaryTextContainer}>
-                            <Text numberOfLines={1} style={styles.primaryText}>
+                            <Text numberOfLines={firstLineNumber} style={styles.primaryText}>
                                 {primaryText}
                             </Text>
                         </View>


### PR DESCRIPTION
We need list items to have more than one line in the primary text.

![simulator screen shot - iphone 6s - 2018-06-04 at 13 01 12](https://user-images.githubusercontent.com/4710865/40914304-f10931c6-67f7-11e8-99e1-78de8c45bdd3.png)

Now you can define a number of lines like this:
`
numberOfLines={{
   primaryText: 3
}}
`