### PR TITLE
Update snackbar to follow new material guidelines, to support onPress and dynamic height

### DIFF
--- a/src/styles/getTheme.js
+++ b/src/styles/getTheme.js
@@ -437,23 +437,32 @@ export default function getTheme(theme, ...more) {
                 color: palette.secondaryTextColor,
             },
         }, theme.listItem)),
-        // https://material.io/guidelines/components/snackbars-toasts.html
+        // https://material.io/design/components/snackbars.html
         snackbar: StyleSheet.create(merge({
             container: {
+                flex: 1,
                 flexDirection: 'row',
-                height: spacing.snackbarHeight,
                 alignItems: 'center',
                 backgroundColor: snackbarColor,
-                paddingHorizontal: 24,
+                paddingHorizontal: 16,
                 ...getPlatformElevation(4),
                 zIndex: 4,
+                borderRadius: 6,
+                margin: 6,
+                position: 'absolute',
+                bottom: 0,
+            },
+            content: {
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
             },
             message: {
                 flex: 1,
                 marginVertical: 14,
                 color: white,
                 ...typography.body2,
-                lineHeight: 14,
+                lineHeight: 16,
             },
             actionContainer: {
                 height: 14,

--- a/src/styles/spacing.js
+++ b/src/styles/spacing.js
@@ -3,5 +3,4 @@ export default {
     // https://material.google.com/layout/metrics-keylines.html#metrics-keylines-touch-target-size
     iconSize: 24,
     avatarSize: 40,
-    snackbarHeight: 48,
 };


### PR DESCRIPTION
- the material design guidelines has changed: https://material.io/design/components/snackbars.html , the animation is different
- it should be possible to have a snackbar with multiple lines and a dynamic height (then we need to know the height, that's why I've added onHeightChange)
- it should be possible to hide the snackbar on press

![untitled7](https://user-images.githubusercontent.com/4710865/41147274-4452b008-6b06-11e8-8125-f5c01664e525.gif)
