### PR TITLE
Revert 'Hide Ripple effect if no onPress* method' to avoid re-rendering

### DIFF
--- a/src/RippleFeedback/RippleFeedbackAndroid.react.js
+++ b/src/RippleFeedback/RippleFeedbackAndroid.react.js
@@ -17,16 +17,10 @@ const defaultProps = {
   borderless: true,
 };
 
-const isRippleVisible = ({ onPress, onLongPress, onPressIn, onPressOut }) =>
-  onPress || onLongPress || onPressIn || onPressOut;
-
 class RippleFeedback extends PureComponent {
   render() {
     const { children, color, borderless, ...otherProps } = this.props;
 
-    if (!isRippleVisible(this.props)) {
-      return children;
-    }
     // we need to get underlayColor as props to this RippleFeedback component, because we can't
     // TouchableNativeFeedback.Ripple function on iOS devices
     const mapProps = { ...otherProps };

--- a/src/RippleFeedback/RippleFeedbackIOS.react.js
+++ b/src/RippleFeedback/RippleFeedbackIOS.react.js
@@ -68,9 +68,6 @@ const styles = StyleSheet.create({
  */
 const MAX_DIAMETER = 200;
 
-const isRippleVisible = ({ onPress, onLongPress, onPressIn, onPressOut }) =>
-  onPress || onLongPress || onPressIn || onPressOut;
-
 class RippleFeedbackIOS extends PureComponent {
   constructor(props, context) {
     super(props, context);
@@ -300,10 +297,6 @@ class RippleFeedbackIOS extends PureComponent {
 
   render() {
     const { children, disabled, style, testID } = this.props;
-
-    if (!isRippleVisible(this.props)) {
-      return children;
-    }
 
     const parent = React.Children.only(children);
 


### PR DESCRIPTION
The component now re-renders every time it's pressed and it makes e.g. `autoFocus` property of `TextInput` unusable because it autofocuses every time it's pressed.

![untitled8](https://user-images.githubusercontent.com/4710865/42097269-045328a8-7bb8-11e8-858f-3cacb943e222.gif)

![untitled7](https://user-images.githubusercontent.com/4710865/42097270-0475d2cc-7bb8-11e8-9d2a-810b2fd17b4b.gif)
