### PR TITLE
BackAndroid is not supported anymore in react-native

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,11 +1,10 @@
 import {
   View,
   BackHandler,
-  ViewPropTypes as RNViewPropTypes,
-  BackAndroid as DeprecatedBackAndroid,
+  ViewPropTypes as RNViewPropTypes
 } from 'react-native';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes; // eslint-disable-line
-const BackAndroid = BackHandler || DeprecatedBackAndroid;
+const BackAndroid = BackHandler; // BackAndroid is not supported anymore in react-native.
 
 export { ViewPropTypes, BackAndroid };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 import {
   View,
   BackHandler,
-  ViewPropTypes as RNViewPropTypes
+  ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes; // eslint-disable-line


### PR DESCRIPTION
I removed BackAndroid import from `utils/index.js` since it is not supported by `react-native` and throws some errors now.