### PR TITLE
IconToggle: abort onPress if the user scrolls

### DIFF
--- a/src/IconToggle/IconToggle.react.js
+++ b/src/IconToggle/IconToggle.react.js
@@ -173,7 +173,9 @@ class IconToggle extends PureComponent {
   onPress() {
     const { disabled, onPress } = this.props;
 
-    onPress && !disabled && onPress();
+    if (onPress && !disabled) {
+      onPress();
+    }
   }
 
   onPressIn() {
@@ -191,7 +193,7 @@ class IconToggle extends PureComponent {
   }
 
   onPressOut() {
-    const { disabled, onPress, maxOpacity } = this.props;
+    const { disabled, maxOpacity } = this.props;
     const { scaleValue, opacityValue } = this.state;
 
     if (!disabled) {

--- a/src/IconToggle/IconToggle.react.js
+++ b/src/IconToggle/IconToggle.react.js
@@ -148,6 +148,7 @@ class IconToggle extends PureComponent {
       rippleSize: getRippleSize(containerSize, props.percent),
     };
 
+    this.onPress = this.onPress.bind(this);
     this.onPressIn = this.onPressIn.bind(this);
     this.onPressOut = this.onPressOut.bind(this);
   }
@@ -167,6 +168,12 @@ class IconToggle extends PureComponent {
         rippleSize: getRippleSize(containerSize, nextProps.percent),
       });
     }
+  }
+
+  onPress() {
+    const { disabled, onPress } = this.props;
+
+    onPress && !disabled && onPress();
   }
 
   onPressIn() {
@@ -195,10 +202,6 @@ class IconToggle extends PureComponent {
         scaleValue.setValue(0.01);
         opacityValue.setValue(maxOpacity);
       });
-
-      if (onPress) {
-        onPress();
-      }
     }
   }
 
@@ -255,6 +258,7 @@ class IconToggle extends PureComponent {
     return (
       <TouchableWithoutFeedback
         testID={testID}
+        onPress={this.onPress}
         onPressIn={this.onPressIn}
         onPressOut={this.onPressOut}
       >


### PR DESCRIPTION
TouchableWithoutFeedback's onPressIn and onPressOut props are not cancelled when a user scrolls. IconToggle was previously calling its onPress prop in a handler for TouchableWithoutFeedback's onPressOut prop. As a result, the consumer-specified onPress handler would not abort if the user initiated scroll events.

This commit moves IconToggle's onPress logic to a TouchableWithoutFeedbacks's onPress handler, causing it to abort if a user scrolls.

Fixes xotahal/react-native-material-ui/issues/382