### PR TITLE
Fix Android shadow node issue (#358)

### DIFF
--- a/src/Drawer/Section.react.js
+++ b/src/Drawer/Section.react.js
@@ -99,7 +99,7 @@ class Section extends PureComponent {
             );
           })}
         </View>
-        {divider && <Divider />}
+        {!!divider && <Divider />}
       </View>
     );
   }

--- a/src/ListItem/ListItem.react.js
+++ b/src/ListItem/ListItem.react.js
@@ -371,7 +371,7 @@ class ListItem extends PureComponent {
               </Text>
             </View>
           </View>
-          {secondaryText && (
+          {!!secondaryText && (
             <View>
               <Text
                 numberOfLines={secondLineNumber}
@@ -381,7 +381,7 @@ class ListItem extends PureComponent {
               </Text>
             </View>
           )}
-          {tertiaryText && (
+          {!!tertiaryText && (
             <View>
               <Text numberOfLines={thirdLineNumber} style={styles.tertiaryText}>
                 {tertiaryText}


### PR DESCRIPTION
See https://github.com/xotahal/react-native-material-ui/issues/358

If secondaryText or tertiaryText are empty strings they evaluate as false.

`'' && someCode()` never runs someCode()

In this case this means that secondaryText (whose value is '') gets put directly into the textViewContainer instead of being wrapped in `<Text></Text>` tags.

You can see the original React Native issue and a comment about this solution here https://github.com/facebook/react-native/issues/13243#issuecomment-335488473