### PR TITLE
Subheader: Fix propTypes typo

### DIFF
--- a/src/Subheader/Subheader.react.js
+++ b/src/Subheader/Subheader.react.js
@@ -11,7 +11,7 @@ const propTypes = {
   inset: PropTypes.bool,
   lines: PropTypes.number,
   style: PropTypes.shape({
-    contaienr: ViewPropTypes.style,
+    container: ViewPropTypes.style,
     text: Text.propTypes.style, // eslint-disable-line
   }),
 };


### PR DESCRIPTION
`contaienr` => `container`

No same typo found in project.