### PR TITLE
Add contentContainer style option to Drawer

### DIFF
--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -51,6 +51,7 @@ const propTypes = {
     children: PropTypes.node.isRequired,
     style: PropTypes.shape({
         container: ScrollView.propTypes.style,
+        contentContainer: View.propTypes.style,
     }),
 };
 ```

--- a/src/Drawer/Drawer.react.js
+++ b/src/Drawer/Drawer.react.js
@@ -14,6 +14,7 @@ const propTypes = {
   children: PropTypes.node.isRequired,
   style: PropTypes.shape({
     container: ViewPropTypes.style,
+    contentContainerStyle: ViewPropTypes.style,
   }),
 };
 const defaultProps = {
@@ -25,6 +26,7 @@ function getStyles(props) {
 
   return {
     container: [drawer.container, props.style.container],
+    contentContainer: [drawer.contentContainer, props.style.contentContainer],
   };
 }
 
@@ -36,7 +38,12 @@ class Drawer extends PureComponent {
 
     return (
       <Container>
-        <ScrollView style={styles.container}>{children}</ScrollView>
+        <ScrollView
+          contentContainerStyle={styles.contentContainer}
+          style={styles.container}
+        >
+          {children}
+        </ScrollView>
       </Container>
     );
   }

--- a/src/Drawer/Drawer.react.js
+++ b/src/Drawer/Drawer.react.js
@@ -14,7 +14,7 @@ const propTypes = {
   children: PropTypes.node.isRequired,
   style: PropTypes.shape({
     container: ViewPropTypes.style,
-    contentContainerStyle: ViewPropTypes.style,
+    contentContainer: ViewPropTypes.style,
   }),
 };
 const defaultProps = {


### PR DESCRIPTION
In my app it's nice to be able to set `contentContainerStyle={{ height: '100%' }}` so that items inside the drawer can flex grow and allow for positioning of items at the bottom of the drawer

![image](https://user-images.githubusercontent.com/303609/48523329-a004fd80-e841-11e8-878c-0c8b61357127.png)
