### PR TITLE
Added check for null, undefined or false children

### DIFF
--- a/src/BottomNavigation/BottomNavigation.react.js
+++ b/src/BottomNavigation/BottomNavigation.react.js
@@ -117,11 +117,12 @@ class BottomNavigation extends PureComponent {
       >
         <View style={styles.actionsContainer}>
           {React.Children.map(children, child =>
-            React.cloneElement(child, {
-              ...child.props,
-              active: child.key === active,
-            }),
-          )}
+            (child != null && child !== false &&
+              React.cloneElement(child, {
+                ...child.props,
+                active: child.key === active,
+              }),
+          ))}
         </View>
       </Animated.View>
     );


### PR DESCRIPTION
Within the current implementation added children that might be `false` or `null` will cause the spread of the child props to throw an error. This should prevent that from happening in the future.

Problem situation reproduced in [this Sandbox](https://codesandbox.io/s/7rz89nlk6)