### PR TITLE
Adding the ability to pass a custom children to button

### DIFF
--- a/src/Button/Button.react.js
+++ b/src/Button/Button.react.js
@@ -42,6 +42,10 @@ const propTypes = {
    */
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /**
+   * You can use to provide a custom button content
+   */
+  children: PropTypes.element,
+  /**
    * Name of Icon set that should be use. From react-native-vector-icons
    */
   iconSet: PropTypes.string,
@@ -200,6 +204,7 @@ class Button extends PureComponent {
       upperCase,
       onLongPress,
       testID,
+      children,
     } = this.props;
 
     const styles = getStyles(this.props, this.state);
@@ -207,7 +212,11 @@ class Button extends PureComponent {
     const content = (
       <View style={styles.container} pointerEvents="box-only">
         {this.renderIcon(styles)}
-        <Text style={styles.text}>{upperCase ? text.toUpperCase() : text}</Text>
+        {
+          children
+            ? children
+            : <Text style={styles.text}>{upperCase ? text.toUpperCase() : text}</Text>
+        }
       </View>
     );
 

--- a/src/Button/__test__/Button.test.js
+++ b/src/Button/__test__/Button.test.js
@@ -1,5 +1,6 @@
 import 'react-native';
 import React from 'react';
+import { View } from 'react-native';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 import Button from '../index';
@@ -83,6 +84,13 @@ describe('Button', () => {
   it('onPress', () => {
     const subheader = renderer
       .create(<Button text="Clear" onPress={() => {}} />)
+      .toJSON();
+
+    expect(subheader).toMatchSnapshot();
+  });
+  it('children', () => {
+    const subheader = renderer
+      .create(<Button><View /></Button>)
       .toJSON();
 
     expect(subheader).toMatchSnapshot();

--- a/src/Button/__test__/__snapshots__/Button.test.js.snap
+++ b/src/Button/__test__/__snapshots__/Button.test.js.snap
@@ -141,6 +141,94 @@ exports[`Button accent, text, icon 1`] = `
 </View>
 `;
 
+exports[`Button children 1`] = `
+<View
+  accessible={true}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  pointerEvents="box-only"
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "borderRadius": 2,
+        "flexDirection": "row",
+        "height": 36,
+        "justifyContent": "center",
+        "paddingHorizontal": 16,
+      },
+      undefined,
+      false,
+      false,
+      false,
+      Object {},
+      undefined,
+    ]
+  }
+  testID={null}
+>
+  <View />
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "rgba(0, 0, 0, 0.87)",
+          "bottom": 0,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1,
+        }
+      }
+    />
+    <View
+      pointerEvents="none"
+      style={
+        Object {
+          "backgroundColor": "rgba(0, 0, 0, 0.87)",
+          "borderRadius": 100,
+          "height": 200,
+          "left": -100,
+          "opacity": 0.12,
+          "position": "absolute",
+          "top": -100,
+          "transform": Array [
+            Object {
+              "scale": 0,
+            },
+          ],
+          "width": 200,
+          "zIndex": 1,
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
 exports[`Button default color 1`] = `
 <View
   accessible={true}


### PR DESCRIPTION
Done this change to allow us to pass a custom children component. This can be util when you need to pass something different than only a text component.